### PR TITLE
demo (DO NOT MERGE)

### DIFF
--- a/rulesets/books/statistics/_config.scss
+++ b/rulesets/books/statistics/_config.scss
@@ -5,7 +5,7 @@
 ==========================================================*/
 
 /*
-  Chapter Review page DEMO
+  Chapter Review page EVEN_BETTER_DEMO
 
   These should be collated at the end of a chapter.
 

--- a/rulesets/books/statistics/_config.scss
+++ b/rulesets/books/statistics/_config.scss
@@ -5,7 +5,7 @@
 ==========================================================*/
 
 /*
-  Chapter Review page
+  Chapter Review page DEMO
 
   These should be collated at the end of a chapter.
 

--- a/rulesets/output/statistics.css
+++ b/rulesets/output/statistics.css
@@ -266,7 +266,7 @@
   STATISTICS PAGES
 ==========================================================*/
 /*
-  Chapter Review page DEMO
+  Chapter Review page EVEN_BETTER_DEMO
 
   These should be collated at the end of a chapter.
 

--- a/rulesets/output/statistics.css
+++ b/rulesets/output/statistics.css
@@ -266,7 +266,7 @@
   STATISTICS PAGES
 ==========================================================*/
 /*
-  Chapter Review page
+  Chapter Review page DEMO
 
   These should be collated at the end of a chapter.
 


### PR DESCRIPTION
This is a Pull Request for the demo to show what it looks like to generate a styleguide when you push changes to GitHub.

# Motivation

When you make a change to the recipes, styling CSS, or the style guide you want to see the new style guide (QA).

- **Bonus:** make sure the Guide showcases all the things that are styled (code coverage)
- **Stretch-goal:** generate a PDF of all the books affected by this change (QA/content dev)

## Click each ▶  below to see a screenshot of what happens

# As soon as you update a file in GitHub (commit)...

<details>
<summary>A status page shows that the style guide build is in progress</summary>

![image](https://cloud.githubusercontent.com/assets/253202/24782087/010d89ca-1b12-11e7-9294-2c63a5e2872e.png)

</details>
<details>
<summary>When you click the <strong>Details</strong> link you see the <a href="https://jenkins.cnx.org:8080/job/Build_cnx-rulesets_Styleguides/58/console">job progress</a></summary>

![image](https://cloud.githubusercontent.com/assets/253202/24782102/14a72edc-1b12-11e7-8057-af5b4697fd25.png)

</details>
<details>
<summary>If you go to the <a href="https://jenkins.cnx.org:8080/job/Build_cnx-rulesets_Styleguides/">Jenkins Job Page</a> you see the job running</summary>

<!--
![image](https://cloud.githubusercontent.com/assets/253202/24782110/21bb1fd4-1b12-11e7-8114-cc3ce34b5c9b.png)
![image](https://cloud.githubusercontent.com/assets/253202/24782134/52fd2646-1b12-11e7-8759-5cda8c885dee.png)
-->

![image](https://cloud.githubusercontent.com/assets/253202/24782140/6083efb6-1b12-11e7-81ac-a3e03a9a5510.png)


</details>
<details>
<summary>If you click the commit status directly you see a popup of all the CI jobs</summary>

It is the same as the one on the bottom of a Pull Request

![image](https://cloud.githubusercontent.com/assets/253202/24782125/4107a83a-1b12-11e7-8540-a51dfd6a276b.png)

</details>

# Once the job completes...

<details>
<summary>The bottom of the Pull Request should look green</summary>


![image](https://cloud.githubusercontent.com/assets/253202/24782663/9a12c60a-1b15-11e7-9b23-045903938fb7.png)

</details>
<details>
<summary>When you click "Show Details" it will show all the CI work that happened</summary>

If you changed code, then this makes sure you added entries in the style guide to cover the code.

![image](https://cloud.githubusercontent.com/assets/253202/24782675/a8eebb84-1b15-11e7-8b09-cc3b6a878c16.png)

</details>
<details>
<summary>Clicking the styleguide <strong>Details</strong> link will show <a href="https://packages.cnx.org/cnx-rulesets/8768afa88ac8fb437e2a8848c9b24c91d34e6032/">all the guides</a> that were generated</summary>

![image](https://cloud.githubusercontent.com/assets/253202/24783026/c8596012-1b17-11e7-8cb7-3c27db7e702c.png)


</details>
<details>
<summary>Clicking one of the guides will show the <a href="https://packages.cnx.org/cnx-rulesets/8768afa88ac8fb437e2a8848c9b24c91d34e6032/statistics/section-book.html">style guide</a> for that book</summary>

Notice the word **DEMO** shows up because that is what we changed in the Pull Request.

![image](https://cloud.githubusercontent.com/assets/253202/24783048/f68b9c66-1b17-11e7-9820-473eeb9825a0.png)

</details>
<details>
<summary>And if you click the commit status you get a similar popup</summary>

This also allows you to look at the style guide generated for this specific commit

![image](https://cloud.githubusercontent.com/assets/253202/24782702/ca4e8b92-1b15-11e7-81a1-29a68d94bd29.png)


</details>

---

> "Don't think of it as being done. The whole idea of being done is kind of the opposite of what I'm trying to achieve"
>  - Christoph Niemann