### PR TITLE
Make sure solutions have been deleted before numbering tables

### DIFF
--- a/rulesets/books/_generator.scss
+++ b/rulesets/books/_generator.scss
@@ -45,6 +45,7 @@ $_symbolsSectionTitle: "Symbols";
 
     @if $moveSolutionTo == $AREA_TRASH {
       @include modify_trash('.#{$className} [data-type="solution"]');
+      @include utils_clearTrash();
     } @else {
       // TODO Skip reconstructing a new object for modify_note
       $label: map-get($note, label);

--- a/rulesets/output/statistics.css
+++ b/rulesets/output/statistics.css
@@ -533,6 +533,8 @@ Formula Review page
   content: pending(bNoteHeader) content(); }
 :pass(1) .try [data-type="solution"] {
   move-to: trash; }
+:pass(1) body:deferred::after {
+  content: clear(trash); }
 
 :pass(2) body {
   counter-reset: chapter; }


### PR DESCRIPTION
Tables are mis-numbered because they are counted before being discarded for good. 

Found in statistics