### PR TITLE
Dev fixes

### DIFF
--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -17,13 +17,22 @@ if [ -f "Brewfile" ] && [ "$(uname -s)" = "Darwin" ]; then
   }
 fi
 
+
+>&2 echo "==> Installing Node package dependencies"
+>&2 echo "Using node: $(node --version)"
+>&2 echo "Using npm: $(npm --version)"
+npm install || exit 1
+
 # Note: Skip rbenv for Travis because it already has ruby
 if [ ! "${CI}" = "true" ] && [ -f ".ruby-version" ]; then
   if [[ -n $(which rbenv) ]]; then
 
     if [ -z "$(rbenv version-name 2>/dev/null)" ]; then
       >&2 echo "==> Installing Ruby…"
-      rbenv install --skip-existing
+      rbenv install --skip-existing || {
+        echo "WARNING: 'rbenv install' errored. I am assuming you know what you are doing (and have sass installed locally) so continuing"
+        exit 0
+      }
     fi
   else
     >&2 echo "WARNING: Skipping rbenv. Using local ruby"
@@ -54,9 +63,3 @@ if [ -f "Gemfile" ]; then
     bundle install --path vendor/gems --quiet --without production
   }
 fi
-
-
->&2 echo "==> Installing Node package dependencies"
->&2 echo "Using node: $(node --version)"
->&2 echo "Using npm: $(npm --version)"
-npm install || exit 1

--- a/scripts/compile-books
+++ b/scripts/compile-books
@@ -14,6 +14,19 @@ then
   RULESET_NAMES=(${arg1})
 fi
 
+# Try running sass locally (using rbenv). If that does not work then try it globally
+if [[ $(bundle exec sass --version) ]]
+then
+  sassBin="bundle exec sass"
+elif [[ $(sass --version) ]]
+then
+  >&2 echo "INFO: Using system-installed $(sass --version)"
+  sassBin="sass"
+else
+  >&2 echo "ERROR: Could not find sass executable"
+  exit 1
+fi
+
 
 for rulesetName in "${RULESET_NAMES[@]}"
 do
@@ -23,17 +36,5 @@ do
 
   >&2 echo "==> Generating ${cssFile}"
 
-  # Try running sass locally (using rbenv). If that does not work then try it globally
-  if [[ $(bundle exec sass --version) ]]
-  then
-    sassBin="bundle exec sass"
-  elif [[ $(sass --version) ]]
-  then
-    >&2 echo "WARNING: Using global sass"
-    sassBin="sass"
-  else
-    >&2 echo "ERROR: Could not find sass executable"
-    exit 1
-  fi
   ${sassBin} ${sassFile} ${cssFile} || exit 1
 done

--- a/scripts/compile-books
+++ b/scripts/compile-books
@@ -15,10 +15,10 @@ then
 fi
 
 # Try running sass locally (using rbenv). If that does not work then try it globally
-if [[ $(bundle exec sass --version) ]]
+if [[ $(bundle exec sass --version 2>/dev/null) ]]
 then
   sassBin="bundle exec sass"
-elif [[ $(sass --version) ]]
+elif [[ $(sass --version 2>/dev/null) ]]
 then
   >&2 echo "INFO: Using system-installed $(sass --version)"
   sassBin="sass"

--- a/scripts/compile-books
+++ b/scripts/compile-books
@@ -23,5 +23,17 @@ do
 
   >&2 echo "==> Generating ${cssFile}"
 
-  bundle exec sass ${sassFile} ${cssFile} || exit 1
+  # Try running sass locally (using rbenv). If that does not work then try it globally
+  if [[ $(bundle exec sass --version) ]]
+  then
+    sassBin="bundle exec sass"
+  elif [[ $(sass --version) ]]
+  then
+    >&2 echo "WARNING: Using global sass"
+    sassBin="sass"
+  else
+    >&2 echo "ERROR: Could not find sass executable"
+    exit 1
+  fi
+  ${sassBin} ${sassFile} ${cssFile} || exit 1
 done

--- a/scripts/generate-guide
+++ b/scripts/generate-guide
@@ -42,10 +42,10 @@ fi
 
 
 # Try running sass locally (using rbenv). If that does not work then try it globally
-if [[ $(bundle exec sass --version) ]]
+if [[ $(bundle exec sass --version 2>/dev/null) ]]
 then
   sassBin="bundle exec sass"
-elif [[ $(sass --version) ]]
+elif [[ $(sass --version 2>/dev/null) ]]
 then
   >&2 echo "INFO: Using system-installed $(sass --version)"
   sassBin="sass"

--- a/scripts/generate-guide
+++ b/scripts/generate-guide
@@ -47,7 +47,7 @@ then
   sassBin="bundle exec sass"
 elif [[ $(sass --version) ]]
 then
-  >&2 echo "WARNING: Using global sass"
+  >&2 echo "INFO: Using system-installed $(sass --version)"
   sassBin="sass"
 else
   >&2 echo "ERROR: Could not find sass executable"

--- a/scripts/generate-guide
+++ b/scripts/generate-guide
@@ -39,8 +39,23 @@ if [ ! -e ${styleguideDir} ]
 then
   mkdir -p ${styleguideDir} || exit 1
 fi
-bundle exec sass ${sassFile} ${cssFile} || exit 1
-bundle exec sass ${sassFile} ${bookCssFile} || exit 1
+
+
+# Try running sass locally (using rbenv). If that does not work then try it globally
+if [[ $(bundle exec sass --version) ]]
+then
+  sassBin="bundle exec sass"
+elif [[ $(sass --version) ]]
+then
+  >&2 echo "WARNING: Using global sass"
+  sassBin="sass"
+else
+  >&2 echo "ERROR: Could not find sass executable"
+  exit 1
+fi
+
+${sassBin} ${sassFile} ${cssFile} || exit 1
+${sassBin} ${sassFile} ${bookCssFile} || exit 1
 
 
 >&2 echo "==> Generating the baked example HTML files"

--- a/scripts/setup
+++ b/scripts/setup
@@ -22,6 +22,7 @@ else
   >&2 echo "==> Skipping virtualenv because already in one"
 fi
 
+pip install -U pip
 
 if [[ -n "${VIRTUAL_ENV}" ]]
 then


### PR DESCRIPTION
- updates `pip` when `scripts/setup` is run
- uses the globally installed `sass` when the rbenv one is not found


Address the stacktrace in https://github.com/Connexions/cnx-rulesets/pull/174#issuecomment-299943157
