### PR TITLE
fix patch reporting

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,5 +2,10 @@ comment:
   layout: "header, diff, changes, uncovered, tree"
   behavior: default
 
+coverage:
+  status:
+    project: on # default
+    patch: off # SCSS files are in the patch but are never covered
+
 # To Turn off comments completely:
 # comment: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,10 +2,13 @@ comment:
   layout: "header, diff, changes, uncovered, tree"
   behavior: default
 
-coverage:
-  status:
-    project: on # default
-    patch: off # SCSS files are in the patch but are never covered
+# Ignore sass files so they do not affect the patch coverage
+ignore:
+  - "rulesets/books/**/*"
+  - "rulesets/mixins/**/*"
+  - "script/**/*"
+  - "js/**/*"
+  - "*"
 
 # To Turn off comments completely:
 # comment: false


### PR DESCRIPTION
because it raises false positives.

@tomjw64 noticed this in #209

and it seems to be because SCSS files are included in the diff but are not marked as hits.

See https://docs.codecov.io/docs/commit-status#section-patch-status